### PR TITLE
Small fixes/resolve technical debt

### DIFF
--- a/exdb/admin.py
+++ b/exdb/admin.py
@@ -2,20 +2,62 @@ from django.contrib import admin
 from .models import Type, Subtype, Section, Keyword, Experience, ExperienceComment, ExperienceApproval, Affiliation, EmailTask, EXDBUser
 
 
+class SubtypeAdmin(admin.ModelAdmin):
+    list_display = ('name', 'needs_verification')
+    search_fields = ('name',)
+
+
+class ExperienceCommentInline(admin.TabularInline):
+    model = ExperienceComment
+    raw_id_fields = ('author',)
+
+
 class ExperienceAdmin(admin.ModelAdmin):
     list_display = ('name', 'description', 'created_datetime', 'author')
+    search_fields = (
+        'name',
+        'description',
+        'author__first_name',
+        'author__last_name',
+        'author__email',
+        'author__username',
+        'planners__first_name',
+        'planners__last_name',
+        'planners__email',
+        'planners__username',
+    )
+    raw_id_fields = ('author', 'recognition', 'next_approver')
+    inlines = (ExperienceCommentInline,)
 
 
 class ExperienceApprovalAdmin(admin.ModelAdmin):
     list_display = ('experience', 'approver', 'timestamp')
+    search_fields = (
+        'experience__name',
+        'approver__first_name',
+        'approver__last_name',
+        'approver__email',
+        'approver__username',
+    )
+    raw_id_fields = ('experience', 'approver')
+
+
+class SectionAdmin(admin.ModelAdmin):
+    list_display = ('name', 'affiliation')
+    search_fields = ('name', 'affiliation__name')
+
+
+class EXDBUserAdmin(admin.ModelAdmin):
+    list_display = ('username', 'first_name', 'last_name', 'email')
+    search_fields = ('username', 'first_name', 'last_name', 'email')
+
 
 admin.site.register(Type)
-admin.site.register(Subtype)
-admin.site.register(Section)
+admin.site.register(Subtype, SubtypeAdmin)
+admin.site.register(Section, SectionAdmin)
 admin.site.register(Keyword)
 admin.site.register(Experience, ExperienceAdmin)
-admin.site.register(ExperienceComment)
 admin.site.register(ExperienceApproval, ExperienceApprovalAdmin)
 admin.site.register(EmailTask)
 admin.site.register(Affiliation)
-admin.site.register(EXDBUser)
+admin.site.register(EXDBUser, EXDBUserAdmin)

--- a/exdb/emails.py
+++ b/exdb/emails.py
@@ -79,7 +79,8 @@ class DailyDigest(EmailTaskBase):
             from_email = settings.SERVER_EMAIL
             subject = settings.EMAIL_SUBJECT_PREFIX + 'Daily Digest'
             for user in self.get_addrs():
-
+                if not user.is_hallstaff():
+                    continue
                 # Find all the approvals that need evaluation and all the experiences that
                 # need to be approved by the current user
                 experience_approvals = ExperienceApproval.objects.filter(

--- a/exdb/emails.py
+++ b/exdb/emails.py
@@ -66,7 +66,7 @@ class DailyDigest(EmailTaskBase):
         experience_approvals_needing_eval = ExperienceApproval.objects.filter(
             experience__status='ad', experience__end_datetime__lt=now())
 
-        users = get_user_model().objects.filter(
+        users = get_user_model().objects.hallstaff().filter(
             Q(approval_queue__pk__in=pending_experiences) |
             Q(approval_set__pk__in=experience_approvals_needing_eval)
         ).distinct()
@@ -79,8 +79,6 @@ class DailyDigest(EmailTaskBase):
             from_email = settings.SERVER_EMAIL
             subject = settings.EMAIL_SUBJECT_PREFIX + 'Daily Digest'
             for user in self.get_addrs():
-                if not user.is_hallstaff():
-                    continue
                 # Find all the approvals that need evaluation and all the experiences that
                 # need to be approved by the current user
                 experience_approvals = ExperienceApproval.objects.filter(

--- a/exdb/forms.py
+++ b/exdb/forms.py
@@ -68,8 +68,8 @@ class ExperienceSaveForm(ModelForm):
         }
 
         labels = {
-            'start_datetime': 'Start Time',
-            'end_datetime': 'End Time',
+            'start_datetime': 'Starting Date & Time',
+            'end_datetime': 'Ending Date & Time',
             'next_approver': 'Supervisor',
             'name': 'Title',
         }

--- a/exdb/forms.py
+++ b/exdb/forms.py
@@ -68,10 +68,10 @@ class ExperienceSaveForm(ModelForm):
         }
 
         labels = {
-            'start_datetime': 'Starting Date & Time',
-            'end_datetime': 'Ending Date & Time',
-            'next_approver': 'Supervisor',
-            'name': 'Title',
+            'start_datetime': _('Starting Date & Time'),
+            'end_datetime': _('Ending Date & Time'),
+            'next_approver': _('Supervisor'),
+            'name': _('Title'),
         }
 
     def __init__(self, *args, **kwargs):

--- a/exdb/models.py
+++ b/exdb/models.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 from django.db import models
+from django.db.models import Q
 from django.utils.timezone import now
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -25,6 +26,30 @@ class EXDBUser(AbstractUser):
         if getattr(self, '_approvable_experiences', None) is None:
             self._approvable_experiences = self.approval_queue.filter(status='pe')
         return self._approvable_experiences
+
+    def editable_experiences(self):
+        if getattr(self, '_editable_experiences', None) is None:
+            user_has_editing_privs = Q(author=self) | (Q(planners=self) & ~Q(status='dr'))
+            if self.is_hallstaff():
+                # Let the staff do whatever they want to non-drafts
+                user_has_editing_privs |= ~Q(status='dr')
+            current_status_allows_edits = ~Q(status__in=('ca', 'co'))
+            event_already_occurred = Q(status='ad') & Q(start_datetime__lte=now())
+            editable_experience = user_has_editing_privs & current_status_allows_edits & ~event_already_occurred
+            self._editable_experiences = Experience.objects.filter(editable_experience).distinct()
+        return self._editable_experiences
+
+    def evaluatable_experiences(self):
+        if getattr(self, '_evaluatable_experiences', None) is None:
+            Qs = Q(author=self) | Q(planners=self)
+            if self.is_hallstaff():
+                experience_approvals = ExperienceApproval.objects.filter(
+                    approver=self, experience__status='ad'
+                )
+                Qs |= Q(pk__in=experience_approvals.values('experience'))
+            self._evaluatable_experiences = Experience.objects.filter(
+                Qs, status='ad', end_datetime__lte=now()).distinct()
+        return self._evaluatable_experiences
 
     def is_hallstaff(self):
         return self.__class__.objects.hallstaff().filter(pk=self.pk).exists()
@@ -157,13 +182,13 @@ class Experience(models.Model):
         return self.status == 'ad' and self.end_datetime <= now()
 
     def get_url(self, user):
-        if self.needs_evaluation():
-            return reverse('conclusion', args=[self.pk])
         if self in user.approvable_experiences() and user.is_hallstaff():
             return reverse('approval', args=[self.pk])
-        if self.status == 'co' or self.start_datetime < now() and self.status == 'ad':
-            return reverse('view_experience', args=[self.pk])
-        return reverse('edit', args=[self.pk])
+        if self in user.evaluatable_experiences():
+            return reverse('conclusion', args=[self.pk])
+        if self in user.editable_experiences():
+            return reverse('edit', args=[self.pk])
+        return reverse('view_experience', args=[self.pk])
 
     def convert_to_dict(self, keys):
         row = model_to_dict(self, fields=keys)

--- a/exdb/models.py
+++ b/exdb/models.py
@@ -22,12 +22,25 @@ class EXDBUser(AbstractUser):
     def is_hallstaff(self):
         return self.groups.filter(name__icontains='hallstaff').exists()
 
+    def __str__(self):
+        if self.first_name or self.last_name:
+            return ' '.join((self.first_name, self.last_name))
+        if self.email:
+            return self.email
+        return self.username
+
+    class Meta:
+        ordering = ['first_name', 'last_name', 'email', 'username']
+
 
 class Type(models.Model):
     name = models.CharField(max_length=300)
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        ordering = ['name']
 
 
 class Subtype(models.Model):
@@ -37,12 +50,18 @@ class Subtype(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ['name']
+
 
 class Affiliation(models.Model):
     name = models.CharField(max_length=300)
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        ordering = ['name']
 
 
 class Section(models.Model):
@@ -52,12 +71,18 @@ class Section(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ['name']
+
 
 class Keyword(models.Model):
     name = models.CharField(max_length=300)
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        ordering = ['name']
 
 
 class Experience(models.Model):

--- a/exdb/models.py
+++ b/exdb/models.py
@@ -23,11 +23,7 @@ class EXDBUser(AbstractUser):
         return self.groups.filter(name__icontains='hallstaff').exists()
 
     def __str__(self):
-        if self.first_name or self.last_name:
-            return ' '.join((self.first_name, self.last_name))
-        if self.email:
-            return self.email
-        return self.username
+        return self.get_full_name() or self.email or self.username
 
     class Meta:
         ordering = ['first_name', 'last_name', 'email', 'username']

--- a/exdb/static/exdb/css/experience_view.css
+++ b/exdb/static/exdb/css/experience_view.css
@@ -1,0 +1,4 @@
+.multiline {
+    display: block;
+    margin-left: 2em;
+}

--- a/exdb/templates/exdb/emails/evaluate.html
+++ b/exdb/templates/exdb/emails/evaluate.html
@@ -1,2 +1,5 @@
-Your experience <a href="{{ url_prefix }}{% url 'conclusion' experience.pk %}">{{ experience.name }}</a> needs to be evaluated.
-
+{% load i18n %}
+{% url 'conclusion' experience.pk as url_suffix %}
+{% blocktrans with experience_name=experience.name %}
+Your experience <a href="{{ url_prefix }}{{ url_suffix }}">{{ experience_name }}</a> needs to be evaluated.
+{% endblocktrans %}

--- a/exdb/templates/exdb/emails/evaluate.html
+++ b/exdb/templates/exdb/emails/evaluate.html
@@ -1,2 +1,2 @@
-Your experience <a href="{{ url_prefix }}{% url 'view_experience' experience.pk %}">{{ experience.name }}</a> needs to be evaluated. 
+Your experience <a href="{{ url_prefix }}{% url 'conclusion' experience.pk %}">{{ experience.name }}</a> needs to be evaluated.
 

--- a/exdb/templates/exdb/experience_view.html
+++ b/exdb/templates/exdb/experience_view.html
@@ -1,14 +1,15 @@
 {% extends "exdb/base.html" %}
 {% load i18n %}
 {% load staticfiles %}
+
 {% block css %}
     {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'exdb/css/experience_approval.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'exdb/css/experience_view.css' %}" />
 {% endblock %}
 
 {% block header_color %} {{ experience.get_status_display|cut:" " }}-background{% endblock %}
 {% block header_title %}
-    <h2>{% trans "View" %} {{ experience.name }}</h2>
+    <h2>{{ experience.name }}</h2>
 {% endblock %}
 
 {% block content %}
@@ -53,11 +54,11 @@
         </p>
         <p>
             <span>{% trans "Description" %}:</span>
-            {{ experience.description }}
+            <span class="multiline">{{ experience.description|linebreaksbr }}</span>
         </p>
         <p>
             <span>{% trans "Goals" %}:</span>
-            {{ experience.goals }}
+            <span class="multiline">{{ experience.goals|linebreaksbr }}</span>
         </p>
         {% if experience.attendance %}
             <p>
@@ -90,7 +91,7 @@
         {% if experience.conclusion %}
             <p>
                 <span>{% trans "Conclusion" %}:</span>
-                {{ experience.conclusion }}
+                <span class="multiline">{{ experience.conclusion|linebreaksbr }}</span>
             </p>
         {% endif %}
     </div>

--- a/exdb/templates/exdb/search.html
+++ b/exdb/templates/exdb/search.html
@@ -56,7 +56,7 @@
                                 {% endfor %}
                             </td>
                             <td class="status">{{ exp.get_status_display }}</td>
-                            <td class="start-time">{{ exp.start_datetime|date:'N j, o g:i A' }}</td>
+                            <td class="start-time">{{ exp.start_datetime|date:'N j, Y g:i A' }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/exdb/tests/browser_tests.py
+++ b/exdb/tests/browser_tests.py
@@ -91,25 +91,25 @@ class CustomRunner(DiscoverRunner, metaclass=CustomRunnerMetaClass):
         self.__class__.exit_perma_driver()
 
     def get_drivers(self):
-        def chrome(): return 'chrome'
+        def chrome(): return 'chrome'  # pylint: disable=multiple-statements
         chrome.driver = webdriver.Chrome
 
-        def edge(): return 'edge'
+        def edge(): return 'edge'  # pylint: disable=multiple-statements
         edge.driver = webdriver.Edge
 
-        def firefox(): return 'firefox'
+        def firefox(): return 'firefox'  # pylint: disable=multiple-statements
         firefox.driver = webdriver.Firefox
 
-        def ie(): return 'ie'
+        def ie(): return 'ie'  # pylint: disable=multiple-statements
         ie.driver = webdriver.Ie
 
-        def none_obj(): return 'none'
+        def none_obj(): return 'none'  # pylint: disable=multiple-statements
         none_obj.driver = 'none'
 
-        def phantomjs(): return 'phantomjs'
+        def phantomjs(): return 'phantomjs'  # pylint: disable=multiple-statements
         phantomjs.driver = webdriver.PhantomJS
 
-        def remote(): return 'remote'
+        def remote(): return 'remote'  # pylint: disable=multiple-statements
         remote.driver = webdriver.Remote
         capabilities = {
             'chromeOptions': {

--- a/exdb/tests/browser_tests.py
+++ b/exdb/tests/browser_tests.py
@@ -91,25 +91,25 @@ class CustomRunner(DiscoverRunner, metaclass=CustomRunnerMetaClass):
         self.__class__.exit_perma_driver()
 
     def get_drivers(self):
-        chrome = lambda: 'chrome'
+        def chrome(): return 'chrome'
         chrome.driver = webdriver.Chrome
 
-        edge = lambda: 'edge'
+        def edge(): return 'edge'
         edge.driver = webdriver.Edge
 
-        firefox = lambda: 'firefox'
+        def firefox(): return 'firefox'
         firefox.driver = webdriver.Firefox
 
-        ie = lambda: 'ie'
+        def ie(): return 'ie'
         ie.driver = webdriver.Ie
 
-        none_obj = lambda: 'none'
+        def none_obj(): return 'none'
         none_obj.driver = 'none'
 
-        phantomjs = lambda: 'phantomjs'
+        def phantomjs(): return 'phantomjs'
         phantomjs.driver = webdriver.PhantomJS
 
-        remote = lambda: 'remote'
+        def remote(): return 'remote'
         remote.driver = webdriver.Remote
         capabilities = {
             'chromeOptions': {

--- a/exdb/tests/integration_tests.py
+++ b/exdb/tests/integration_tests.py
@@ -137,6 +137,7 @@ class ModelCoverageTest(StandardTestCase):
         e = self.create_experience('ad')
         e.start_datetime = make_aware(datetime.now(), timezone=utc) - timedelta(days=1)
         e.end_datetime = make_aware(datetime.now(), timezone=utc) + timedelta(days=1)
+        e.save()
         self.assertEqual(e.get_url(self.clients['ra'].user_object), reverse('view_experience', args=[e.pk]),
                          "The url for view_experience should have been returned")
 

--- a/exdb/tests/integration_tests.py
+++ b/exdb/tests/integration_tests.py
@@ -881,6 +881,17 @@ class EmailTest(StandardTestCase):
 
         emails.send_mass_mail = mass_mail
 
+    def test_daily_digest_excludes_non_hallstaff(self):
+        e = self.create_experience('ad', start=(self.test_date - timedelta(days=3)),
+                                   end=(self.test_date - timedelta(days=2)))
+        e.next_approver = self.clients['ra'].user_object
+        e.save()
+        ExperienceApproval.objects.get_or_create(experience=e, approver=e.next_approver)
+
+        self.send_emails()
+
+        self.assertEqual(len(mail.outbox), 1, "Only one evaluation reminder email should've been sent")
+
 
 class ExperienceSearchViewTest(StandardTestCase):
 

--- a/exdbproject/settings.py
+++ b/exdbproject/settings.py
@@ -120,9 +120,29 @@ LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
 
+DATE_INPUT_FORMATS = [
+    '%m/%d/%Y', '%m/%d/%y', '%Y-%m-%d',  # '10/25/2006', '10/25/06', '2006-10-25'
+    '%b %d %Y', '%b %d, %Y',            # 'Oct 25 2006', 'Oct 25, 2006'
+    '%d %b %Y', '%d %b, %Y',            # '25 Oct 2006', '25 Oct, 2006'
+    '%B %d %Y', '%B %d, %Y',            # 'October 25 2006', 'October 25, 2006'
+    '%d %B %Y', '%d %B, %Y',            # '25 October 2006', '25 October, 2006'
+]
+
+TIME_INPUT_FORMATS = [
+    '%I:%M %p',     # '02:30 PM'
+    '%I:%M%p',      # '02:30PM'
+    '%I:%M:%S %p',  # '02:30:59 PM'
+    '%I:%M:%S%p',   # '02:30:59PM'
+    '%I %p',        # '02 PM'
+    '%I%p',         # '02PM'
+    '%H:%M:%S',     # '14:30:59'
+    '%H:%M:%S.%f',  # '14:30:59.000200'
+    '%H:%M',        # '14:30'
+]
+
 USE_I18N = True
 
-USE_L10N = True
+USE_L10N = False  # Necessary for custom input formats
 
 USE_TZ = True
 


### PR DESCRIPTION
This PR will make Django admin more useful, fix the evaluation/conclusion link in reminder emails, set a default ordering for all models to make the forms easier to use, show full names for users instead of just usernames, and allow more american-friendly datetime input formats.